### PR TITLE
Release v1.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased] - (release date)
 
+## [1.1.4] - 2024-10-01
+
 ### Fixed
 
 - Legacy meta queries with multiple alternatives no longer cause Annimate to crash.
@@ -47,7 +49,8 @@
 Initial version
 
 <!-- next-url -->
-[Unreleased]: https://github.com/matthias-stemmler/annimate/compare/v1.1.3...HEAD
+[Unreleased]: https://github.com/matthias-stemmler/annimate/compare/v1.1.4...HEAD
+[1.1.4]: https://github.com/matthias-stemmler/annimate/compare/v1.1.3...v1.1.4
 [1.1.3]: https://github.com/matthias-stemmler/annimate/compare/v1.1.2...v1.1.3
 [1.1.2]: https://github.com/matthias-stemmler/annimate/compare/v1.1.1...v1.1.2
 [1.1.1]: https://github.com/matthias-stemmler/annimate/compare/v1.1.0...v1.1.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,7 +65,7 @@ dependencies = [
 
 [[package]]
 name = "annimate_core"
-version = "1.1.3"
+version = "1.1.4"
 dependencies = [
  "cargo_metadata",
  "csv",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "annimate_desktop"
-version = "1.1.3"
+version = "1.1.4"
 dependencies = [
  "annimate_core",
  "itertools 0.13.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.1.3"
+version = "1.1.4"
 authors = ["Matthias Stemmler <matthias.stemmler@gmail.com>"]
 edition = "2021"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ Annimate is available as a desktop application for Windows and Linux. MacOS is c
 
 | Operating system    | Format         | Installation required? | Automatic updates | Download link                      |
 | ------------------- | -------------- | ---------------------- | ----------------- | ---------------------------------- |
-| Windows             | Installer      | yes                    | yes               | [Annimate_1.1.3_x64-setup.exe][1]  |
-| Linux               | AppImage       | no                     | yes               | [annimate_1.1.3_amd64.AppImage][2] |
-| Linux (Debian only) | Debian package | yes                    | no                | [annimate_1.1.3_amd64.deb][3]      |
+| Windows             | Installer      | yes                    | yes               | [Annimate_1.1.4_x64-setup.exe][1]  |
+| Linux               | AppImage       | no                     | yes               | [annimate_1.1.4_amd64.AppImage][2] |
+| Linux (Debian only) | Debian package | yes                    | no                | [annimate_1.1.4_amd64.deb][3]      |
 
 For a list of previous releases, see the [releases page](https://github.com/matthias-stemmler/annimate/releases).
 
@@ -45,7 +45,7 @@ This comes without prebundled dependencies, so it is a lot smaller. It can only 
 Download the .deb file (see the table above) and run the following commands in a shell:
 
 ```sh
-sudo dpkg -i annimate_1.1.3_amd64.deb
+sudo dpkg -i annimate_1.1.4_amd64.deb
 annimate
 ```
 
@@ -128,9 +128,9 @@ See [CHANGELOG.md](CHANGELOG.md)
 
 Licensed under the Apache License, Version 2.0 (see [LICENSE](LICENSE) or https://www.apache.org/licenses/LICENSE-2.0)
 
-[1]: https://github.com/matthias-stemmler/annimate/releases/download/v1.1.3/Annimate_1.1.3_x64-setup.exe
-[2]: https://github.com/matthias-stemmler/annimate/releases/download/v1.1.3/annimate_1.1.3_amd64.AppImage
-[3]: https://github.com/matthias-stemmler/annimate/releases/download/v1.1.3/annimate_1.1.3_amd64.deb
+[1]: https://github.com/matthias-stemmler/annimate/releases/download/v1.1.4/Annimate_1.1.4_x64-setup.exe
+[2]: https://github.com/matthias-stemmler/annimate/releases/download/v1.1.4/annimate_1.1.4_amd64.AppImage
+[3]: https://github.com/matthias-stemmler/annimate/releases/download/v1.1.4/annimate_1.1.4_amd64.deb
 
 [^1]:
     **Krause, Thomas & Zeldes, Amir** (2016):

--- a/release.json
+++ b/release.json
@@ -1,3 +1,3 @@
 {
-  "versionBump": "patch"
+  "versionBump": "none"
 }


### PR DESCRIPTION
## [1.1.4] - 2024-10-01

### Fixed

- Legacy meta queries with multiple alternatives no longer cause Annimate to crash.
- Nodes for queries with optional nodes in between are now listed correctly.

[1.1.4]: https://github.com/matthias-stemmler/annimate/compare/v1.1.3...v1.1.4