### PR TITLE
Release v1.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased] - (release date)
 
+## [1.3.3] - 2024-11-27
+
 ### Fixed
 
 - Optional query nodes are now always excluded from the selection under "Match annotation" and "Match in context" since they never correspond to match nodes.
@@ -90,7 +92,8 @@
 Initial version
 
 <!-- next-url -->
-[Unreleased]: https://github.com/matthias-stemmler/annimate/compare/v1.3.2...HEAD
+[Unreleased]: https://github.com/matthias-stemmler/annimate/compare/v1.3.3...HEAD
+[1.3.3]: https://github.com/matthias-stemmler/annimate/compare/v1.3.2...v1.3.3
 [1.3.2]: https://github.com/matthias-stemmler/annimate/compare/v1.3.1...v1.3.2
 [1.3.1]: https://github.com/matthias-stemmler/annimate/compare/v1.3.0...v1.3.1
 [1.3.0]: https://github.com/matthias-stemmler/annimate/compare/v1.2.0...v1.3.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,7 +80,7 @@ dependencies = [
 
 [[package]]
 name = "annimate_core"
-version = "1.3.2"
+version = "1.3.3"
 dependencies = [
  "cargo_metadata 0.19.0",
  "csv",
@@ -100,7 +100,7 @@ dependencies = [
 
 [[package]]
 name = "annimate_desktop"
-version = "1.3.2"
+version = "1.3.3"
 dependencies = [
  "annimate_core",
  "itertools 0.13.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.3.2"
+version = "1.3.3"
 authors = ["Matthias Stemmler <matthias.stemmler@gmail.com>"]
 edition = "2021"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ Annimate is available as a desktop application for Windows, Linux and macOS. The
 
 | Operating system | Format         | Installation required? | Automatic updates | Download link                      |
 | ---------------- | -------------- | ---------------------- | ----------------- | ---------------------------------- |
-| Windows          | Installer      | ✅                     | ✅                | [Annimate_1.3.2_x64-setup.exe][1]  |
-| Linux            | AppImage       | ❌                     | ✅                | [Annimate_1.3.2_amd64.AppImage][2] |
-| Linux            | Debian package | ✅                     | ❌                | [Annimate_1.3.2_amd64.deb][3]      |
+| Windows          | Installer      | ✅                     | ✅                | [Annimate_1.3.3_x64-setup.exe][1]  |
+| Linux            | AppImage       | ❌                     | ✅                | [Annimate_1.3.3_amd64.AppImage][2] |
+| Linux            | Debian package | ✅                     | ❌                | [Annimate_1.3.3_amd64.deb][3]      |
 | macOS (silicon)  | App Bundle     | ✅                     | ✅                | [Annimate_aarch64.app.tar.gz][4]   |
 | macOS (Intel)    | App Bundle     | ✅                     | ✅                | [Annimate_x64.app.tar.gz][5]       |
 
@@ -46,11 +46,11 @@ See [CHANGELOG.md](CHANGELOG.md)
 
 Licensed under the Apache License, Version 2.0 (see [LICENSE](LICENSE) or https://www.apache.org/licenses/LICENSE-2.0)
 
-[1]: https://github.com/matthias-stemmler/annimate/releases/download/v1.3.2/Annimate_1.3.2_x64-setup.exe
-[2]: https://github.com/matthias-stemmler/annimate/releases/download/v1.3.2/Annimate_1.3.2_amd64.AppImage
-[3]: https://github.com/matthias-stemmler/annimate/releases/download/v1.3.2/Annimate_1.3.2_amd64.deb
-[4]: https://github.com/matthias-stemmler/annimate/releases/download/v1.3.2/Annimate_aarch64.app.tar.gz
-[5]: https://github.com/matthias-stemmler/annimate/releases/download/v1.3.2/Annimate_x64.app.tar.gz
+[1]: https://github.com/matthias-stemmler/annimate/releases/download/v1.3.3/Annimate_1.3.3_x64-setup.exe
+[2]: https://github.com/matthias-stemmler/annimate/releases/download/v1.3.3/Annimate_1.3.3_amd64.AppImage
+[3]: https://github.com/matthias-stemmler/annimate/releases/download/v1.3.3/Annimate_1.3.3_amd64.deb
+[4]: https://github.com/matthias-stemmler/annimate/releases/download/v1.3.3/Annimate_aarch64.app.tar.gz
+[5]: https://github.com/matthias-stemmler/annimate/releases/download/v1.3.3/Annimate_x64.app.tar.gz
 
 [^1]:
     **Krause, Thomas & Zeldes, Amir** (2016):

--- a/docs/user-guide/src/installation.md
+++ b/docs/user-guide/src/installation.md
@@ -12,7 +12,7 @@ On Windows, Annimate comes with an installer that takes care of the installation
 
 In order to install Annimate, go through the following steps:
 
-1. Download the installer `.exe` file from GitHub: [Annimate_1.3.2_x64-setup.exe][1]
+1. Download the installer `.exe` file from GitHub: [Annimate_1.3.3_x64-setup.exe][1]
 2. Run the downloaded `.exe` file and follow the instructions of the installation wizard
 3. Afterwards, you can run Annimate through the Windows start menu entry and/or the link on your desktop, depending on the options you chose in the installation wizard
 
@@ -37,7 +37,7 @@ The Annimate AppImage is a self-contained application bundle that includes all o
 
 In order to use the AppImage, go through the following steps:
 
-1. Download the `.AppImage` file from GitHub: [Annimate_1.3.2_amd64.AppImage][2]
+1. Download the `.AppImage` file from GitHub: [Annimate_1.3.3_amd64.AppImage][2]
 2. Make it executable:
    ```shell
    chmod a+x Annimate*.AppImage
@@ -66,7 +66,7 @@ On Debian and its derivatives (such as Ubuntu), you can alternatively install An
 
 In order to install the Debian package, go through the following steps:
 
-1. Download the `.deb` file from GitHub: [Annimate_1.3.2_amd64.deb][3]
+1. Download the `.deb` file from GitHub: [Annimate_1.3.3_amd64.deb][3]
 2. Install it:
    ```shell
    sudo dpkg -i ./Annimate_*_amd64.deb
@@ -138,11 +138,11 @@ In case you see an error message when Annimate tries to install the update, make
 
 For reference, you can find the most recent and all previous releases of Annimate on the [Releases](https://github.com/matthias-stemmler/annimate/releases) page on GitHub.
 
-[1]: https://github.com/matthias-stemmler/annimate/releases/download/v1.3.2/Annimate_1.3.2_x64-setup.exe
-[2]: https://github.com/matthias-stemmler/annimate/releases/download/v1.3.2/Annimate_1.3.2_amd64.AppImage
-[3]: https://github.com/matthias-stemmler/annimate/releases/download/v1.3.2/Annimate_1.3.2_amd64.deb
-[4]: https://github.com/matthias-stemmler/annimate/releases/download/v1.3.2/Annimate_aarch64.app.tar.gz
-[5]: https://github.com/matthias-stemmler/annimate/releases/download/v1.3.2/Annimate_x64.app.tar.gz
+[1]: https://github.com/matthias-stemmler/annimate/releases/download/v1.3.3/Annimate_1.3.3_x64-setup.exe
+[2]: https://github.com/matthias-stemmler/annimate/releases/download/v1.3.3/Annimate_1.3.3_amd64.AppImage
+[3]: https://github.com/matthias-stemmler/annimate/releases/download/v1.3.3/Annimate_1.3.3_amd64.deb
+[4]: https://github.com/matthias-stemmler/annimate/releases/download/v1.3.3/Annimate_aarch64.app.tar.gz
+[5]: https://github.com/matthias-stemmler/annimate/releases/download/v1.3.3/Annimate_x64.app.tar.gz
 
 ## What's Next?
 

--- a/release.json
+++ b/release.json
@@ -1,3 +1,3 @@
 {
-  "versionBump": "patch"
+  "versionBump": "none"
 }


### PR DESCRIPTION
## [1.3.3] - 2024-11-27

### Fixed

- Optional query nodes are now always excluded from the selection under "Match annotation" and "Match in context" since they never correspond to match nodes.

[1.3.3]: https://github.com/matthias-stemmler/annimate/compare/v1.3.2...v1.3.3