### PR TITLE
Release v1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased] - (release date)
 
+## [1.8.0] - 2026-05-21
+
 ### Added
 
 - Added a new column type "Edge annotation" for exporting annotations of edges between match nodes. See the User Guide for details.
@@ -169,7 +171,8 @@
 Initial version
 
 <!-- next-url -->
-[Unreleased]: https://github.com/matthias-stemmler/annimate/compare/v1.7.0...HEAD
+[Unreleased]: https://github.com/matthias-stemmler/annimate/compare/v1.8.0...HEAD
+[1.8.0]: https://github.com/matthias-stemmler/annimate/compare/v1.7.0...v1.8.0
 [1.7.0]: https://github.com/matthias-stemmler/annimate/compare/v1.6.0...v1.7.0
 [1.6.0]: https://github.com/matthias-stemmler/annimate/compare/v1.5.0...v1.6.0
 [1.5.0]: https://github.com/matthias-stemmler/annimate/compare/v1.4.0...v1.5.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,7 +60,7 @@ dependencies = [
 
 [[package]]
 name = "annimate_core"
-version = "1.7.0"
+version = "1.8.0"
 dependencies = [
  "cargo_metadata 0.23.1",
  "csv",
@@ -82,7 +82,7 @@ dependencies = [
 
 [[package]]
 name = "annimate_desktop"
-version = "1.7.0"
+version = "1.8.0"
 dependencies = [
  "annimate_core",
  "itertools 0.14.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["annimate_core", "annimate_desktop/src-tauri"]
 resolver = "3"
 
 [workspace.package]
-version = "1.7.0"
+version = "1.8.0"
 authors = ["Matthias Stemmler <matthias.stemmler@gmail.com>"]
 edition = "2024"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ Annimate is available as a desktop application for Windows, Linux and macOS. The
 
 | Operating system | Format         | Installation required? | Automatic updates | Download link                      |
 | ---------------- | -------------- | ---------------------- | ----------------- | ---------------------------------- |
-| Windows          | Installer      | ✅                     | ✅                | [Annimate_1.7.0_x64-setup.exe][1]  |
-| Linux            | AppImage       | ❌                     | ✅                | [Annimate_1.7.0_amd64.AppImage][2] |
-| Linux            | Debian package | ✅                     | ❌                | [Annimate_1.7.0_amd64.deb][3]      |
+| Windows          | Installer      | ✅                     | ✅                | [Annimate_1.8.0_x64-setup.exe][1]  |
+| Linux            | AppImage       | ❌                     | ✅                | [Annimate_1.8.0_amd64.AppImage][2] |
+| Linux            | Debian package | ✅                     | ❌                | [Annimate_1.8.0_amd64.deb][3]      |
 | macOS (silicon)  | App Bundle     | ✅                     | ✅                | [Annimate_aarch64.app.tar.gz][4]   |
 | macOS (Intel)    | App Bundle     | ✅                     | ✅                | [Annimate_x64.app.tar.gz][5]       |
 
@@ -54,11 +54,11 @@ See [CHANGELOG.md](CHANGELOG.md)
 
 Licensed under the Apache License, Version 2.0 (see [LICENSE](LICENSE) or https://www.apache.org/licenses/LICENSE-2.0)
 
-[1]: https://github.com/matthias-stemmler/annimate/releases/download/v1.7.0/Annimate_1.7.0_x64-setup.exe
-[2]: https://github.com/matthias-stemmler/annimate/releases/download/v1.7.0/Annimate_1.7.0_amd64.AppImage
-[3]: https://github.com/matthias-stemmler/annimate/releases/download/v1.7.0/Annimate_1.7.0_amd64.deb
-[4]: https://github.com/matthias-stemmler/annimate/releases/download/v1.7.0/Annimate_aarch64.app.tar.gz
-[5]: https://github.com/matthias-stemmler/annimate/releases/download/v1.7.0/Annimate_x64.app.tar.gz
+[1]: https://github.com/matthias-stemmler/annimate/releases/download/v1.8.0/Annimate_1.8.0_x64-setup.exe
+[2]: https://github.com/matthias-stemmler/annimate/releases/download/v1.8.0/Annimate_1.8.0_amd64.AppImage
+[3]: https://github.com/matthias-stemmler/annimate/releases/download/v1.8.0/Annimate_1.8.0_amd64.deb
+[4]: https://github.com/matthias-stemmler/annimate/releases/download/v1.8.0/Annimate_aarch64.app.tar.gz
+[5]: https://github.com/matthias-stemmler/annimate/releases/download/v1.8.0/Annimate_x64.app.tar.gz
 
 [^1]:
     **Krause, Thomas & Zeldes, Amir** (2016):

--- a/docs/user-guide/src/installation.md
+++ b/docs/user-guide/src/installation.md
@@ -12,7 +12,7 @@ On Windows, Annimate comes with an installer that takes care of the installation
 
 In order to install Annimate, go through the following steps:
 
-1. Download the installer `.exe` file from GitHub: [Annimate_1.7.0_x64-setup.exe][1]
+1. Download the installer `.exe` file from GitHub: [Annimate_1.8.0_x64-setup.exe][1]
 2. Run the downloaded `.exe` file and follow the instructions of the installation wizard
 3. Afterwards, you can run Annimate through the Windows start menu entry and/or the link on your desktop, depending on the options you chose in the installation wizard
 
@@ -37,7 +37,7 @@ The Annimate AppImage is a self-contained application bundle that includes all o
 
 In order to use the AppImage, go through the following steps:
 
-1. Download the `.AppImage` file from GitHub: [Annimate_1.7.0_amd64.AppImage][2]
+1. Download the `.AppImage` file from GitHub: [Annimate_1.8.0_amd64.AppImage][2]
 2. Make it executable:
    ```shell
    chmod a+x Annimate*.AppImage
@@ -66,7 +66,7 @@ On Debian and its derivatives (such as Ubuntu), you can alternatively install An
 
 In order to install the Debian package, go through the following steps:
 
-1. Download the `.deb` file from GitHub: [Annimate_1.7.0_amd64.deb][3]
+1. Download the `.deb` file from GitHub: [Annimate_1.8.0_amd64.deb][3]
 2. Install it:
    ```shell
    sudo dpkg -i ./Annimate_*_amd64.deb
@@ -143,11 +143,11 @@ In case Annimate is installed in a folder that requires administrator permission
 
 For reference, you can find the most recent and all previous releases of Annimate on the [Releases](https://github.com/matthias-stemmler/annimate/releases) page on GitHub.
 
-[1]: https://github.com/matthias-stemmler/annimate/releases/download/v1.7.0/Annimate_1.7.0_x64-setup.exe
-[2]: https://github.com/matthias-stemmler/annimate/releases/download/v1.7.0/Annimate_1.7.0_amd64.AppImage
-[3]: https://github.com/matthias-stemmler/annimate/releases/download/v1.7.0/Annimate_1.7.0_amd64.deb
-[4]: https://github.com/matthias-stemmler/annimate/releases/download/v1.7.0/Annimate_aarch64.app.tar.gz
-[5]: https://github.com/matthias-stemmler/annimate/releases/download/v1.7.0/Annimate_x64.app.tar.gz
+[1]: https://github.com/matthias-stemmler/annimate/releases/download/v1.8.0/Annimate_1.8.0_x64-setup.exe
+[2]: https://github.com/matthias-stemmler/annimate/releases/download/v1.8.0/Annimate_1.8.0_amd64.AppImage
+[3]: https://github.com/matthias-stemmler/annimate/releases/download/v1.8.0/Annimate_1.8.0_amd64.deb
+[4]: https://github.com/matthias-stemmler/annimate/releases/download/v1.8.0/Annimate_aarch64.app.tar.gz
+[5]: https://github.com/matthias-stemmler/annimate/releases/download/v1.8.0/Annimate_x64.app.tar.gz
 
 ## What's Next?
 

--- a/release.json
+++ b/release.json
@@ -1,3 +1,3 @@
 {
-  "versionBump": "minor"
+  "versionBump": "none"
 }


### PR DESCRIPTION
## [1.8.0] - 2026-05-21

### Added

- Added a new column type "Edge annotation" for exporting annotations of edges between match nodes. See the User Guide for details.
  - NOTE: When using this for the first time for corpora that were already imported before the update, it may take some time until the available options are loaded. Afterwards, they will load faster due to caching.
- The Annimate Debian package now supports automatic updates.

### Fixed

- Exports of "Match in context" columns no longer fail when the query matches a token without segmentation coverage.
- Fixed display and on-click selection of query validation error locations for queries containing certain special characters.

[1.8.0]: https://github.com/matthias-stemmler/annimate/compare/v1.7.0...v1.8.0