### PR TITLE
Release v1.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased] - (release date)
 
+## [1.9.0] - 2026-08-22
+
 ### Added
 
 - Added a "Query node" section at the end of the options under "Annotation" for "Match annotation" columns, which can be used to export the query fragment or the variable of the selected query node instead of one of its annotations. For queries with multiple alternatives, this tells you which alternative applied for each match. See the User Guide for details.
@@ -186,7 +188,8 @@
 Initial version
 
 <!-- next-url -->
-[Unreleased]: https://github.com/matthias-stemmler/annimate/compare/v1.8.1...HEAD
+[Unreleased]: https://github.com/matthias-stemmler/annimate/compare/v1.9.0...HEAD
+[1.9.0]: https://github.com/matthias-stemmler/annimate/compare/v1.8.1...v1.9.0
 [1.8.1]: https://github.com/matthias-stemmler/annimate/compare/v1.8.0...v1.8.1
 [1.8.0]: https://github.com/matthias-stemmler/annimate/compare/v1.7.0...v1.8.0
 [1.7.0]: https://github.com/matthias-stemmler/annimate/compare/v1.6.0...v1.7.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -28,8 +28,8 @@ keywords:
   - corpus linguistics
   - data export
 license: Apache-2.0
-version: 1.8.1
-date-released: "2026-06-14"
+version: 1.9.0
+date-released: "2026-08-22"
 references:
   - authors:
       - given-names: Matthias

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,7 +60,7 @@ dependencies = [
 
 [[package]]
 name = "annimate_core"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "cargo_metadata 0.23.1",
  "csv",
@@ -82,7 +82,7 @@ dependencies = [
 
 [[package]]
 name = "annimate_desktop"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "annimate_core",
  "itertools 0.15.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["annimate_core", "annimate_desktop/src-tauri"]
 resolver = "3"
 
 [workspace.package]
-version = "1.8.1"
+version = "1.9.0"
 authors = ["Matthias Stemmler <matthias.stemmler@gmail.com>"]
 edition = "2024"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -31,11 +31,11 @@ Annimate is available as a desktop application for Windows, Linux and macOS. The
 
 | Operating system | Format         | Installation required? | Auto-updates supported? | Download link                          |
 | ---------------- | -------------- | ---------------------- | ----------------------- | -------------------------------------- |
-| Windows          | Installer      | ➕                     | ✅                      | [Annimate_1.8.1_x64-setup.exe][1]      |
-| Linux            | AppImage       | ➖                     | ✅                      | [Annimate_1.8.1_amd64.AppImage][2]     |
-| Linux            | Debian package | ➕                     | ✅                      | [Annimate_1.8.1_amd64.deb][3]          |
-| macOS (silicon)  | App Bundle     | ➕                     | ✅                      | [Annimate_1.8.1_aarch64.app.tar.gz][4] |
-| macOS (Intel)    | App Bundle     | ➕                     | ✅                      | [Annimate_1.8.1_x64.app.tar.gz][5]     |
+| Windows          | Installer      | ➕                     | ✅                      | [Annimate_1.9.0_x64-setup.exe][1]      |
+| Linux            | AppImage       | ➖                     | ✅                      | [Annimate_1.9.0_amd64.AppImage][2]     |
+| Linux            | Debian package | ➕                     | ✅                      | [Annimate_1.9.0_amd64.deb][3]          |
+| macOS (silicon)  | App Bundle     | ➕                     | ✅                      | [Annimate_1.9.0_aarch64.app.tar.gz][4] |
+| macOS (Intel)    | App Bundle     | ➕                     | ✅                      | [Annimate_1.9.0_x64.app.tar.gz][5]     |
 
 For a list of previous releases, see the [releases page](https://github.com/matthias-stemmler/annimate/releases).
 
@@ -59,11 +59,11 @@ See [CHANGELOG.md](CHANGELOG.md)
 
 Licensed under the Apache License, Version 2.0 (see [LICENSE](LICENSE) or https://www.apache.org/licenses/LICENSE-2.0)
 
-[1]: https://github.com/matthias-stemmler/annimate/releases/download/v1.8.1/Annimate_1.8.1_x64-setup.exe
-[2]: https://github.com/matthias-stemmler/annimate/releases/download/v1.8.1/Annimate_1.8.1_amd64.AppImage
-[3]: https://github.com/matthias-stemmler/annimate/releases/download/v1.8.1/Annimate_1.8.1_amd64.deb
-[4]: https://github.com/matthias-stemmler/annimate/releases/download/v1.8.1/Annimate_1.8.1_aarch64.app.tar.gz
-[5]: https://github.com/matthias-stemmler/annimate/releases/download/v1.8.1/Annimate_1.8.1_x64.app.tar.gz
+[1]: https://github.com/matthias-stemmler/annimate/releases/download/v1.9.0/Annimate_1.9.0_x64-setup.exe
+[2]: https://github.com/matthias-stemmler/annimate/releases/download/v1.9.0/Annimate_1.9.0_amd64.AppImage
+[3]: https://github.com/matthias-stemmler/annimate/releases/download/v1.9.0/Annimate_1.9.0_amd64.deb
+[4]: https://github.com/matthias-stemmler/annimate/releases/download/v1.9.0/Annimate_1.9.0_aarch64.app.tar.gz
+[5]: https://github.com/matthias-stemmler/annimate/releases/download/v1.9.0/Annimate_1.9.0_x64.app.tar.gz
 
 [^1]:
     **Krause, Thomas & Zeldes, Amir** (2016):

--- a/docs/user-guide/src/installation.md
+++ b/docs/user-guide/src/installation.md
@@ -12,7 +12,7 @@ On Windows, Annimate comes with an installer that takes care of the installation
 
 In order to install Annimate, go through the following steps:
 
-1. Download the installer `.exe` file from GitHub: [Annimate_1.8.1_x64-setup.exe][1]
+1. Download the installer `.exe` file from GitHub: [Annimate_1.9.0_x64-setup.exe][1]
 2. Run the downloaded `.exe` file and follow the instructions of the installation wizard
 3. Afterwards, you can run Annimate through the Windows start menu entry and/or the link on your desktop, depending on the options you chose in the installation wizard
 
@@ -37,7 +37,7 @@ The Annimate AppImage is a self-contained application bundle that runs on all co
 
 In order to use the AppImage, go through the following steps:
 
-1. Download the `.AppImage` file from GitHub: [Annimate_1.8.1_amd64.AppImage][2]
+1. Download the `.AppImage` file from GitHub: [Annimate_1.9.0_amd64.AppImage][2]
 2. Make it executable:
    ```shell
    chmod a+x Annimate*.AppImage
@@ -66,7 +66,7 @@ On Debian and its derivatives (such as Ubuntu), you can alternatively install An
 
 In order to install the Debian package, go through the following steps:
 
-1. Download the `.deb` file from GitHub: [Annimate_1.8.1_amd64.deb][3]
+1. Download the `.deb` file from GitHub: [Annimate_1.9.0_amd64.deb][3]
 2. Install it:
    ```shell
    sudo dpkg -i ./Annimate_*_amd64.deb
@@ -104,8 +104,8 @@ Check the [Apple Support](https://support.apple.com/en-us/116943) to find out wh
 In order to install Annimate, go through the following steps:
 
 1. Download the `.tar.gz` file from GitHub:
-   - [Annimate_1.8.1_aarch64.app.tar.gz][4] for Apple silicon processors
-   - [Annimate_1.8.1_x64.app.tar.gz][5] for Intel processors
+   - [Annimate_1.9.0_aarch64.app.tar.gz][4] for Apple silicon processors
+   - [Annimate_1.9.0_x64.app.tar.gz][5] for Intel processors
 2. Double-click on the `.tar.gz` file in your `Downloads` folder to extract it:
    ![Screenshot of macOS archive file](img/macos-archive.png)
 
@@ -154,11 +154,11 @@ In case Annimate is installed in a folder that requires administrator permission
 
 For reference, you can find the most recent and all previous releases of Annimate on the [Releases](https://github.com/matthias-stemmler/annimate/releases) page on GitHub.
 
-[1]: https://github.com/matthias-stemmler/annimate/releases/download/v1.8.1/Annimate_1.8.1_x64-setup.exe
-[2]: https://github.com/matthias-stemmler/annimate/releases/download/v1.8.1/Annimate_1.8.1_amd64.AppImage
-[3]: https://github.com/matthias-stemmler/annimate/releases/download/v1.8.1/Annimate_1.8.1_amd64.deb
-[4]: https://github.com/matthias-stemmler/annimate/releases/download/v1.8.1/Annimate_1.8.1_aarch64.app.tar.gz
-[5]: https://github.com/matthias-stemmler/annimate/releases/download/v1.8.1/Annimate_1.8.1_x64.app.tar.gz
+[1]: https://github.com/matthias-stemmler/annimate/releases/download/v1.9.0/Annimate_1.9.0_x64-setup.exe
+[2]: https://github.com/matthias-stemmler/annimate/releases/download/v1.9.0/Annimate_1.9.0_amd64.AppImage
+[3]: https://github.com/matthias-stemmler/annimate/releases/download/v1.9.0/Annimate_1.9.0_amd64.deb
+[4]: https://github.com/matthias-stemmler/annimate/releases/download/v1.9.0/Annimate_1.9.0_aarch64.app.tar.gz
+[5]: https://github.com/matthias-stemmler/annimate/releases/download/v1.9.0/Annimate_1.9.0_x64.app.tar.gz
 
 ## What's Next?
 

--- a/release.json
+++ b/release.json
@@ -1,3 +1,3 @@
 {
-  "versionBump": "minor"
+  "versionBump": "none"
 }


### PR DESCRIPTION
## [1.9.0] - 2026-08-22

### Added

- Added a "Query node" section at the end of the options under "Annotation" for "Match annotation" columns, which can be used to export the query fragment or the variable of the selected query node instead of one of its annotations. For queries with multiple alternatives, this tells you which alternative applied for each match. See the User Guide for details.

### Changed

- The download files for macOS now include the version number in their names, as on the other platforms.

[1.9.0]: https://github.com/matthias-stemmler/annimate/compare/v1.8.1...v1.9.0